### PR TITLE
Fix saved circuit label for user problems

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2657,7 +2657,7 @@ function renderSavedList() {
     li.style.margin = '6px 0';
     const label = data.stageId != null
       ? `Stage ${String(data.stageId).padStart(2, '0')}`
-      : `Problem ${data.problemKey}`;
+      : `Problem ${data.problemTitle || data.problemKey}`;
     li.innerHTML = `
       <strong>${label}</strong>
       — ${new Date(data.timestamp).toLocaleString()}
@@ -2784,6 +2784,7 @@ function saveCircuit() {
   const data = {
     stageId: currentLevel,
     problemKey: currentCustomProblemKey,
+    problemTitle: currentCustomProblem ? currentCustomProblem.title : undefined,
     timestamp: new Date().toISOString(),
     grid: getGridData(),
     wires: getWireData(),


### PR DESCRIPTION
## Summary
- store problem title when saving circuits
- show the problem title in saved circuit list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68898cf2a5308332b31951593c07cb2f