### PR TITLE
Add onboarding tutorial for first visit

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,6 +366,7 @@
         <div class="tut-controls">
           <button id="tutPrevBtn">이전</button>
           <button id="tutNextBtn">다음</button>
+          <button id="tutFinishBtn" style="display:none;">튜토리얼 마치기</button>
           <button id="tutCloseBtn">닫기</button>
         </div>
       </div>

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -918,18 +918,21 @@ html, body {
   /* 튜토리얼 모달 배경을 살짝 더 어둡게 */
   .tutorial-modal {
     background-color: rgba(0, 0, 0, 0.7);
-    /* 기존 0.5 → 0.7 */
   }
 
-  /* 튜토리얼 콘텐츠 박스 크기·모서리 조정 */
   .tutorial-modal .tutorial-content {
-    max-width: 450px;
-    /* 폭을 약간 넓게 */
-    border-radius: 12px;
-    /* 모서리 둥글게 */
-    padding: 2.5rem;
-    /* 여백 좀 늘리기 */
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    max-height: none;
+    border-radius: 0;
+    padding: 2rem;
+    box-sizing: border-box;
+    box-shadow: none;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
   }
 
   /* 버튼 스타일 강조 */


### PR DESCRIPTION
## Summary
- display tutorial modal fullscreen
- add a finish button to jump directly to Stage 1
- automatically show tutorial after login when not completed
- start at the earliest uncleared stage when finishing the tutorial

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6889f37ed128833285a9257b4726078b