### PR TITLE
Enhance hint modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,7 +281,7 @@
     <div id="hintModal" class="modal" style="display:none;">
       <div class="modal-content">
         <h2>💡 힌트</h2>
-        <div id="hintButtons" class="modal-buttons" style="flex-wrap:wrap; margin-bottom:1rem;"></div>
+        <div id="hintButtons" class="modal-buttons" style="flex-wrap:wrap; margin-bottom:1rem; justify-content:center;"></div>
         <div id="hintTimerContainer" class="modal-buttons" style="justify-content:center; margin-bottom:1rem;">
           <span id="nextHintTimer"></span>
           <button id="adHintBtn">광고 보고 힌트 얻기</button>

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -4229,9 +4229,11 @@ function renderHintButtons(hints, progress, cooldownUntil) {
   const container = document.getElementById('hintButtons');
   container.innerHTML = '';
   const now = Date.now();
+  const hasAvailable = progress < hints.length && now >= cooldownUntil;
   hints.forEach((hint, i) => {
     const btn = document.createElement('button');
-    btn.textContent = `힌트 ${i + 1} (${hint.type})`;
+    const lock = i < progress ? '🔓' : '🔒';
+    btn.textContent = `${lock} 힌트 ${i + 1} (${hint.type})`;
     btn.onclick = () => showHint(i);
     if (i < progress) {
       btn.classList.add('open');
@@ -4246,6 +4248,8 @@ function renderHintButtons(hints, progress, cooldownUntil) {
     }
     container.appendChild(btn);
   });
+  const adBtn = document.getElementById('adHintBtn');
+  if (adBtn) adBtn.style.display = hasAvailable ? 'none' : 'inline-block';
 }
 
 function openHintModal(stage) {
@@ -4256,6 +4260,8 @@ function openHintModal(stage) {
   }
   currentHintStage = stage;
   document.getElementById('hintModal').style.display = 'flex';
+  const adBtn = document.getElementById('adHintBtn');
+  if (adBtn) adBtn.onclick = () => alert('준비중인 기능입니다.');
   loadHintProgress(stage, progress => {
     currentHintProgress = progress;
     checkHintCooldown(until => {

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1823,6 +1823,12 @@ html, body {
   background-color: #e6ffe6;
 }
 
+#hintButtons {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
 /* Hint modal buttons */
 #hintButtons button {
   width: 100px;


### PR DESCRIPTION
## Summary
- center hint list in the modal
- show lock emoji on hint buttons
- hide ad-hint button when a hint is immediately available
- alert when clicking the ad-hint button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a28cb7e3483328584bc632fde6e78