### PR TITLE
Add lock icons to hint buttons

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -4232,8 +4232,11 @@ function renderHintButtons(hints, progress, cooldownUntil) {
   const hasAvailable = progress < hints.length && now >= cooldownUntil;
   hints.forEach((hint, i) => {
     const btn = document.createElement('button');
-    const lock = i < progress ? '🔓' : '🔒';
-    btn.textContent = `${lock} 힌트 ${i + 1} (${hint.type})`;
+    const lockIcon = document.createElement('span');
+    lockIcon.className = 'lock-icon';
+    lockIcon.textContent = i < progress ? '🔓' : '🔒';
+    btn.appendChild(lockIcon);
+    btn.appendChild(document.createTextNode(` 힌트 ${i + 1} (${hint.type})`));
     btn.onclick = () => showHint(i);
     if (i < progress) {
       btn.classList.add('open');

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1835,6 +1835,12 @@ html, body {
   height: 100px;
   font-size: 1rem;
   margin: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+#hintButtons .lock-icon {
+  margin-right: 0.25rem;
 }
 #hintButtons button.open {
   background-color: #87CEFA;


### PR DESCRIPTION
## Summary
- show open or closed lock emoji for each hint
- improve layout of hint buttons

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688a2bc2f69c8332bbbd8ae82bf5fb9c