### PR TITLE
Update hint button layout

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -4232,11 +4232,12 @@ function renderHintButtons(hints, progress, cooldownUntil) {
   const hasAvailable = progress < hints.length && now >= cooldownUntil;
   hints.forEach((hint, i) => {
     const btn = document.createElement('button');
+    btn.appendChild(document.createTextNode(`힌트 ${i + 1} (${hint.type})`));
+    btn.appendChild(document.createElement('br'));
     const lockIcon = document.createElement('span');
     lockIcon.className = 'lock-icon';
     lockIcon.textContent = i < progress ? '🔓' : '🔒';
     btn.appendChild(lockIcon);
-    btn.appendChild(document.createTextNode(` 힌트 ${i + 1} (${hint.type})`));
     btn.onclick = () => showHint(i);
     if (i < progress) {
       btn.classList.add('open');

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -1836,11 +1836,12 @@ html, body {
   font-size: 1rem;
   margin: 0.25rem;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
 }
 #hintButtons .lock-icon {
-  margin-right: 0.25rem;
+  margin-top: 0.25rem;
 }
 #hintButtons button.open {
   background-color: #87CEFA;


### PR DESCRIPTION
## Summary
- arrange hint buttons vertically and show lock state below the text
- adjust CSS for new layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a2dab748c8332a50bf20f8a2253fa