### PR TITLE
Prompt nickname after first Google login from main screen

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2640,7 +2640,7 @@ function handleGoogleLogin(user) {
       if (dbName) {
         localStorage.setItem(`googleNickname_${uid}`, dbName);
         applyGoogleNickname(dbName, oldName);
-      } else if (oldName) {
+      } else if (oldName && !loginFromMainScreen) {
         // 기존 게스트 닉네임을 구글 계정에 연결하고 병합 여부를 묻는다
         localStorage.setItem(`googleNickname_${uid}`, oldName);
         db.ref(`google/${uid}`).set({ uid, nickname: oldName });


### PR DESCRIPTION
## Summary
- Show nickname registration modal when logging in with Google from the main screen for the first time
- Allow keeping or changing existing guest nickname, storing the chosen nickname in localStorage and DB

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688acb3496788332a80178d0f1e561c4