### PR TITLE
Make tutorial modal scrollable

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -935,7 +935,8 @@ html, body {
   flex-direction: column;
   justify-content: flex-start;
   align-items: stretch;
-  height: 100%;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
 }
 
 .tutorial-modal .tut-controls {


### PR DESCRIPTION
## Summary
- allow tutorial modal content to scroll so navigation buttons are always visible

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_688b090dba18833296c856d7e0ed07e8