### PR TITLE
Center game layout and enable horizontal scrolling

### DIFF
--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -43,6 +43,7 @@ html, body {
     margin: 0;
     /* 혹시 기본 마진 있으면 제거 */
     overflow-x: auto;
+    width: 100%;
   }
 
   #gameLayout {
@@ -54,7 +55,7 @@ html, body {
     align-items: center;
     /* 상하 중앙 */
     gap: 2rem;
-    margin: 0;
+    margin: 0 auto;
     /* inline style로 준 margin-top 제거 */
     padding-bottom: 60px;
     /* 메뉴바 높이에 맞춰 조정 */


### PR DESCRIPTION
## Summary
- keep game screen full-width and allow horizontal scrolling if content overflows
- center main game layout to remove empty space on the right

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b26d72f2c8332be492b5d633ab94d