### PR TITLE
Use video for tutorials and double playback speed

### DIFF
--- a/index.html
+++ b/index.html
@@ -367,9 +367,8 @@
     <div id="tutorialModal" class="modal tutorial-modal" style="display:none;">
       <div class="modal-content tutorial-content">
         <h2 id="tutTitle"></h2>
-        <!-- 여기 이미지 자리 -->
-        <img id="tutImg" class="tutorial-img" src alt="튜토리얼 이미지"
-          style="display:none;">
+        <!-- 여기 영상 자리 -->
+        <video id="tutImg" class="tutorial-img" style="display:none;" muted loop playsinline></video>
         <p id="tutDesc"></p>
         <div class="tut-controls">
           <button id="tutPrevBtn">이전</button>
@@ -448,7 +447,7 @@
     </div>
     <div id="stageTutorialModal" class="modal" style="display:none;">
       <div class="modal-content">
-        <img id="stageTutImg" class="tutorial-img" src="" alt="tutorial">
+        <video id="stageTutImg" class="tutorial-img" muted loop playsinline></video>
         <p id="stageTutDesc"></p>
         <button id="stageTutBtn">시작하기</button>
       </div>

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -2113,10 +2113,15 @@ function showTutorial(idx) {
   tutTitle.textContent = step.title;
   tutDesc.textContent = step.desc;
 
-  // 이미지가 있으면 보이게, 없으면 숨기기
+  // 이미지(또는 영상)가 있으면 보이게, 없으면 숨기기
   if (step.img) {
     tutImg.src = step.img;
     tutImg.style.display = "block";
+    if (tutImg.tagName === 'VIDEO') {
+      tutImg.playbackRate = 2;
+      tutImg.currentTime = 0;
+      tutImg.play();
+    }
   } else {
     tutImg.style.display = "none";
   }
@@ -2180,6 +2185,11 @@ function showStageTutorial(level, done) {
     const step = steps[idx];
     img.src = step.img;
     desc.textContent = step.desc;
+    if (img.tagName === 'VIDEO') {
+      img.playbackRate = 2;
+      img.currentTime = 0;
+      img.play();
+    }
     btn.textContent = (idx === steps.length - 1) ? t('stageTutBtn') : t('tutNextBtn');
   };
   btn.onclick = () => {


### PR DESCRIPTION
## Summary
- Render tutorial and stage animations with `<video>` elements
- Force videos to play at double speed for quicker tutorials

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689309292b788332a9ee379e6702b6a7