### PR TITLE
feat: export circuit GIF

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,6 +360,7 @@
         <button id="viewRankingBtn">🏆 랭킹 보기</button>
         <button id="showIntroBtn">ℹ️ 스테이지 안내</button>
         <button id="hintBtn">💡 힌트</button>
+        <button id="exportGifBtn">📷 GIF 내보내기</button>
         <button id="backToLevelsBtn">← 레벨 선택으로</button>
         <button id="nextStageBtnMenu">다음 스테이지 →</button>
       </div>
@@ -436,6 +437,7 @@
     const db = firebase.database();
   </script>
     <script src="lang.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gif.js@0.2.0/dist/gif.js"></script>
     <script src="script.v1.4.js"></script>
 
     <div id="levelIntroModal" style="display:none" class="modal">

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -17,6 +17,11 @@ let problemOutputsValid = false;
 let problemScreenPrev = null;  // 문제 출제 화면 진입 이전 화면 기록
 let loginFromMainScreen = false;  // 메인 화면에서 로그인 여부 추적
 
+// 캡처용 보이지 않는 캔버스
+const captureCanvas = document.createElement('canvas');
+captureCanvas.style.display = 'none';
+document.body.appendChild(captureCanvas);
+
 // 초기 로딩 관련
 const initialTasks = [];
 function hideLoadingScreen() {
@@ -4626,5 +4631,123 @@ async function gradeProblemAnimated(key, problem) {
     const hintsUsed=parseInt(localStorage.getItem(`hintsUsed_${key}`)||'0');
     saveProblemRanking(key, blockCounts, usedWires, hintsUsed);
   }
+}
+
+// ----- GIF 캡처 기능 -----
+
+function getCircuitSnapshot() {
+  const blocks = Array.from(grid.querySelectorAll('.cell.block'));
+  const values = new Map();
+  blocks
+    .filter(b => b.dataset.type === 'INPUT')
+    .forEach(b => values.set(b, b.dataset.value === '1'));
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const node of blocks) {
+      const oldVal = values.get(node);
+      const newVal = computeBlock(node, values);
+      if (newVal !== undefined && newVal !== oldVal) {
+        values.set(node, newVal);
+        changed = true;
+      }
+    }
+  }
+
+  const blockSnap = blocks.map(b => ({
+    row: b.row,
+    col: b.col,
+    type: b.dataset.type,
+    name: b.dataset.name,
+    active: values.get(b) || false
+  }));
+
+  const wireSnap = wires.map(w => ({
+    path: w.path.map(c => ({ row: c.row, col: c.col })),
+    active: values.get(w.start) || false
+  }));
+
+  return { blocks: blockSnap, wires: wireSnap, totalFrames: 20 };
+}
+
+function drawCaptureFrame(ctx, state, frame) {
+  const cellSize = 50;
+  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+  ctx.lineWidth = 4;
+  state.wires.forEach(w => {
+    const pts = w.path.map(p => ({
+      x: p.col * cellSize + cellSize / 2,
+      y: p.row * cellSize + cellSize / 2
+    }));
+
+    ctx.strokeStyle = '#999';
+    ctx.beginPath();
+    ctx.moveTo(pts[0].x, pts[0].y);
+    for (let i = 1; i < pts.length; i++) {
+      ctx.lineTo(pts[i].x, pts[i].y);
+    }
+    ctx.stroke();
+
+    if (w.active) {
+      const progress = Math.floor((frame / state.totalFrames) * pts.length);
+      if (progress > 0) {
+        ctx.strokeStyle = '#ff0000';
+        ctx.beginPath();
+        ctx.moveTo(pts[0].x, pts[0].y);
+        for (let i = 1; i < Math.min(progress + 1, pts.length); i++) {
+          ctx.lineTo(pts[i].x, pts[i].y);
+        }
+        ctx.stroke();
+      }
+    }
+  });
+
+  state.blocks.forEach(b => {
+    const x = b.col * cellSize;
+    const y = b.row * cellSize;
+    ctx.fillStyle = b.active ? '#ffeb3b' : '#e0e0ff';
+    ctx.fillRect(x, y, cellSize, cellSize);
+    ctx.strokeStyle = '#000';
+    ctx.strokeRect(x, y, cellSize, cellSize);
+    ctx.fillStyle = '#000';
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(b.type || '', x + cellSize / 2, y + cellSize / 2);
+  });
+}
+
+function captureGIF(state) {
+  captureCanvas.width = GRID_COLS * 50;
+  captureCanvas.height = GRID_ROWS * 50;
+  const ctx = captureCanvas.getContext('2d');
+  const gif = new GIF({ workers: 2, quality: 10 });
+
+  for (let f = 0; f < state.totalFrames; f++) {
+    drawCaptureFrame(ctx, state, f);
+    gif.addFrame(ctx, { copy: true, delay: 100 });
+  }
+
+  gif.on('finished', blob => {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'circuit.gif';
+    a.click();
+  });
+
+  gif.render();
+}
+
+function handleGIFExport() {
+  const state = getCircuitSnapshot();
+  captureGIF(state);
+}
+
+const exportBtn = document.getElementById('exportGifBtn');
+if (exportBtn) {
+  exportBtn.addEventListener('click', handleGIFExport);
 }
 


### PR DESCRIPTION
## Summary
- add gif.js library and menu bar button to export the circuit as GIF
- implement off-screen canvas and rendering helpers to draw animated frames from circuit state
- assemble frames into a downloadable GIF and hook up export button

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894374afc0483329735abda3350f858