### PR TITLE
feat: export circuit GIF

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,6 +360,7 @@
         <button id="viewRankingBtn">🏆 랭킹 보기</button>
         <button id="showIntroBtn">ℹ️ 스테이지 안내</button>
         <button id="hintBtn">💡 힌트</button>
+        <button id="exportGifBtn">📷 GIF 내보내기</button>
         <button id="backToLevelsBtn">← 레벨 선택으로</button>
         <button id="nextStageBtnMenu">다음 스테이지 →</button>
       </div>
@@ -436,6 +437,7 @@
     const db = firebase.database();
   </script>
     <script src="lang.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gif.js@0.2.0/dist/gif.js"></script>
     <script src="script.v1.4.js"></script>
 
     <div id="levelIntroModal" style="display:none" class="modal">


### PR DESCRIPTION
## Summary
- add gif.js library and menu bar button to export the circuit as GIF
- implement off-screen canvas and rendering helpers to draw animated frames from circuit state
- assemble frames into a downloadable GIF and hook up export button
- ensure integer canvas dimensions and use ImageData frames to avoid getImageData errors when exporting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894374afc0483329735abda3350f858