### PR TITLE
Show GIF preview during export

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,6 +403,15 @@
         </div>
       </div>
     </div>
+    <!-- GIF 미리보기 모달 -->
+    <div id="gifModal" class="modal" style="display:none;">
+      <div class="modal-content">
+        <canvas id="captureCanvas" style="max-width:100%; height:auto;"></canvas>
+        <div class="modal-buttons" style="margin-top:1rem;">
+          <button id="closeGifModal">닫기</button>
+        </div>
+      </div>
+    </div>
     <div id="clearedModal" class="modal" style="display: none;">
       <div class="modal-content">
         <h2 id="clearedTitle">스테이지 <span id="clearedStageNumber"></span> 클리어!</h2>

--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -17,10 +17,15 @@ let problemOutputsValid = false;
 let problemScreenPrev = null;  // 문제 출제 화면 진입 이전 화면 기록
 let loginFromMainScreen = false;  // 메인 화면에서 로그인 여부 추적
 
-// 캡처용 보이지 않는 캔버스
-const captureCanvas = document.createElement('canvas');
-captureCanvas.style.display = 'none';
-document.body.appendChild(captureCanvas);
+// GIF 미리보기 캔버스 (모달 내부에 존재)
+const captureCanvas = document.getElementById('captureCanvas');
+const gifModal = document.getElementById('gifModal');
+const closeGifModalBtn = document.getElementById('closeGifModal');
+if (closeGifModalBtn) {
+  closeGifModalBtn.addEventListener('click', () => {
+    if (gifModal) gifModal.style.display = 'none';
+  });
+}
 
 // 초기 로딩 관련
 const initialTasks = [];
@@ -4719,7 +4724,7 @@ function drawCaptureFrame(ctx, state, frame) {
   });
 }
 
-function captureGIF(state) {
+function captureGIF(state, onFinish) {
   const cols = Math.max(1, Math.floor(Number(GRID_COLS)));
   const rows = Math.max(1, Math.floor(Number(GRID_ROWS)));
   captureCanvas.width = cols * 50;
@@ -4742,6 +4747,7 @@ function captureGIF(state) {
     a.download = 'circuit.gif';
     a.click();
     URL.revokeObjectURL(url);
+    if (typeof onFinish === 'function') onFinish();
   });
 
   gif.render();
@@ -4749,7 +4755,10 @@ function captureGIF(state) {
 
 function handleGIFExport() {
   const state = getCircuitSnapshot();
-  captureGIF(state);
+  if (gifModal) gifModal.style.display = 'flex';
+  captureGIF(state, () => {
+    if (gifModal) gifModal.style.display = 'none';
+  });
 }
 
 const exportBtn = document.getElementById('exportGifBtn');


### PR DESCRIPTION
## Summary
- Add `gifModal` with `captureCanvas` to preview GIF frames
- Update GIF export logic to display modal and close on completion

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68944026fa448332850b038b3588614c