### PR TITLE
Enhance GIF wire animation

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -4676,7 +4676,7 @@ function getCircuitSnapshot() {
   const rows = Math.max(1, Math.floor(Number(GRID_ROWS)));
   const cols = Math.max(1, Math.floor(Number(GRID_COLS)));
 
-  return { blocks: blockSnap, wires: wireSnap, rows, cols, totalFrames: 40 };
+  return { blocks: blockSnap, wires: wireSnap, rows, cols, totalFrames: 80 };
 }
 
 function drawCaptureFrame(ctx, state, frame) {
@@ -4720,12 +4720,12 @@ function drawCaptureFrame(ctx, state, frame) {
     }
     ctx.stroke();
 
-    // 모든 도선에 교차하는 반투명 검은색 흐름 표시
+    // 검정색과 배경색이 번갈아 흐르는 선 표시
     ctx.save();
-    ctx.strokeStyle = 'rgba(0,0,0,0.5)';
-    ctx.lineWidth = 2;
-    ctx.setLineDash([8, 8]);
-    ctx.lineDashOffset = -(frame * 4);
+    ctx.strokeStyle = '#fff';
+    ctx.lineWidth = 1;
+    ctx.setLineDash([16, 16]);
+    ctx.lineDashOffset = -(frame * 2);
     ctx.beginPath();
     ctx.moveTo(pts[0].x, pts[0].y);
     for (let i = 1; i < pts.length; i++) {


### PR DESCRIPTION
## Summary
- Extend GIF capture to 80 frames for smoother playback.
- Animate wire flow with alternating black and background-colored segments using thinner, longer dashes.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68944fb200b0833296f13504e83919a8