### PR TITLE
Reset wire state on stage change

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -942,6 +942,9 @@ document.querySelectorAll(".levelBtn").forEach(btn => {
 
 function startLevel(level) {
   resetCaptureCanvas();
+  clearWirePreview();
+  wireTrace = [];
+  wires = [];
   const [rows, cols] = levelGridSizes[level] || [6, 6];
   GRID_ROWS = rows;
   GRID_COLS = cols;


### PR DESCRIPTION
## Summary
- Clear wire preview and arrays when starting a new stage
- Reset capture canvas each time a stage is loaded to avoid leftover wiring

## Testing
- `node -c script.v1.4.js`


------
https://chatgpt.com/codex/tasks/task_e_68946ecb78008332a6028d0fdcca2d86