### PR TITLE
feat: show gif preview with save and share options

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,15 +403,25 @@
         </div>
       </div>
     </div>
-    <!-- GIF 미리보기 모달 -->
+    <!-- GIF 결과 모달 -->
     <div id="gifModal" class="modal" style="display:none;">
       <div class="modal-content">
-        <canvas id="captureCanvas" style="max-width:100%; height:auto;"></canvas>
+        <img id="gifPreview" style="max-width:100%; height:auto;" />
         <div class="modal-buttons" style="margin-top:1rem;">
+          <button id="saveGifBtn">이미지 저장</button>
+          <button id="shareGifBtn">공유하기</button>
           <button id="closeGifModal">닫기</button>
         </div>
       </div>
     </div>
+    <!-- GIF 생성 중 로딩 화면 -->
+    <div id="gifLoadingModal" class="modal" style="display:none;">
+      <div class="modal-content">
+        <p>GIF 생성중...</p>
+      </div>
+    </div>
+    <!-- 캡처용 캔버스 (화면에 표시되지 않음) -->
+    <canvas id="captureCanvas" style="display:none;"></canvas>
     <div id="clearedModal" class="modal" style="display: none;">
       <div class="modal-content">
         <h2 id="clearedTitle">스테이지 <span id="clearedStageNumber"></span> 클리어!</h2>


### PR DESCRIPTION
## Summary
- hide capture canvas and show GIF preview modal with save and share buttons
- display loading modal during GIF generation

## Testing
- `node --version`
- `node --check script.v1.4.js`


------
https://chatgpt.com/codex/tasks/task_e_68947bfd0540833290dc48eb45ccd550