### PR TITLE
Remove automatic GIF download and make GIF modal scrollable

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -42,13 +42,8 @@ if (closeGifModalBtn) {
 }
 if (saveGifBtn) {
   saveGifBtn.addEventListener('click', () => {
-    if (!currentGifBlob) return;
-    const url = URL.createObjectURL(currentGifBlob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'circuit.gif';
-    a.click();
-    URL.revokeObjectURL(url);
+    if (!currentGifUrl) return;
+    window.open(currentGifUrl, '_blank');
   });
 }
 if (shareGifBtn) {

--- a/style.v1.4.css
+++ b/style.v1.4.css
@@ -984,6 +984,16 @@ html, body {
   overflow-y: auto;
 }
 
+#gifModal {
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+#gifModal .modal-content {
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+}
+
   /* ── ① 공통: 페이지 전체 배경 (비게임·게임 모두) ── */
   html, body {
     height: 100%;


### PR DESCRIPTION
## Summary
- Remove automatic download when saving generated GIFs by opening the image in a new tab instead.
- Ensure GIF creation modal scrolls vertically if its content exceeds the viewport.

## Testing
- `node --check script.v1.4.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689480a347c88332a8ee4d01e44e759d