### PR TITLE
Reset wires for custom problems

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -4651,6 +4651,8 @@ function setupCustomBlockPanel(problem) {
 }
 
 function startCustomProblem(key, problem) {
+  wireTrace = [];
+  wires = [];
   currentCustomProblem = problem;
   currentCustomProblemKey = key;
   currentLevel = null;


### PR DESCRIPTION
## Summary
- Clear wire and wireTrace arrays when starting a custom problem so user-made puzzles begin with a clean state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689495d5e1288332aa3efa1701f0817a