### PR TITLE
Fix truth table rendering for special character stage names

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -1792,12 +1792,27 @@ function showLevelIntro(level, callback) {
 
   // 진리표 렌더링
   const keys = Object.keys(data.table[0]);
-  table.innerHTML = `
-    <tr>${keys.map(k => `<th>${k}</th>`).join('')}</tr>
-    ${data.table.map(row =>
-    `<tr>${keys.map(k => `<td>${row[k]}</td>`).join('')}</tr>`
-  ).join('')}
-  `;
+  table.innerHTML = "";
+
+  // 헤더 행 생성
+  const headerRow = document.createElement("tr");
+  keys.forEach(k => {
+    const th = document.createElement("th");
+    th.textContent = k; // 특수문자 안전 처리
+    headerRow.appendChild(th);
+  });
+  table.appendChild(headerRow);
+
+  // 데이터 행 생성
+  data.table.forEach(row => {
+    const tr = document.createElement("tr");
+    keys.forEach(k => {
+      const td = document.createElement("td");
+      td.textContent = row[k];
+      tr.appendChild(td);
+    });
+    table.appendChild(tr);
+  });
 
   modal.style.display = "flex";
   modal.style.backgroundColor = "white";


### PR DESCRIPTION
## Summary
- Render stage intro truth tables using DOM nodes and textContent to handle special characters in header names.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f49bd4748332b1ebef93616add5d