### PR TITLE
Ensure game area padding updates on stage entry

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -3027,6 +3027,7 @@ function collapseMenuBarForMobile() {
   }
 
   adjustGridZoom();
+  updatePadding();
 }
 
 function setupSettings() {
@@ -3053,18 +3054,19 @@ function setupSettings() {
   });
 }
 
-function setupGameAreaPadding() {
+function updatePadding() {
   const menuBar = document.getElementById('menuBar');
   const gameArea = document.getElementById('gameArea');
   if (!menuBar || !gameArea) return;
 
-  function updatePadding() {
-    if (window.matchMedia('(max-width: 1024px)').matches) {
-      gameArea.style.paddingBottom = '';
-    } else {
-      gameArea.style.paddingBottom = menuBar.offsetHeight + 'px';
-    }
+  if (window.matchMedia('(max-width: 1024px)').matches) {
+    gameArea.style.paddingBottom = '';
+  } else {
+    gameArea.style.paddingBottom = menuBar.offsetHeight + 'px';
   }
+}
+
+function setupGameAreaPadding() {
   window.addEventListener('load', updatePadding);
   updatePadding();
   window.addEventListener('resize', updatePadding);


### PR DESCRIPTION
## Summary
- Make `updatePadding` a global helper and register it for load/resize events
- Call `updatePadding` when collapsing the menu bar so padding refreshes on stage entry

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a8448c9a88332b0a8b471391cff1f