### PR TITLE
Refresh level selection lists when returning from game

### DIFF
--- a/script.v1.4.js
+++ b/script.v1.4.js
@@ -1001,8 +1001,14 @@ document.getElementById("backToLevelsBtn").onclick = () => {
   if (currentCustomProblem) {
     currentCustomProblem = null;
     userProblemsScreen.style.display = 'block';
+    renderUserProblemList();
   } else {
     chapterStageScreen.style.display = "block";
+    renderChapterList();
+    const chapter = chapterData[selectedChapterIndex];
+    if (chapter && chapter.id !== 'user') {
+      renderStageList(chapter.stages);
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- Re-render chapter, stage, and user problem lists when clicking "Back to level selection" so the UI reflects newly unlocked content

## Testing
- `node --check script.v1.4.js`


------
https://chatgpt.com/codex/tasks/task_e_689a955d97208332b7d0abf48fe0dbfb